### PR TITLE
Change from PERCONA_SCHEMA to mysql for mariabackup

### DIFF
--- a/ansible/roles/mariadb/defaults/main.yml
+++ b/ansible/roles/mariadb/defaults/main.yml
@@ -125,7 +125,7 @@ mariabackup_tag: "{{ mariadb_tag }}"
 mariabackup_image_full: "{{ mariabackup_image }}:{{ mariabackup_tag }}"
 
 mariadb_backup_host: "{{ groups[mariadb_shard_group][0] }}"
-mariadb_backup_database_schema: "PERCONA_SCHEMA"
+mariadb_backup_database_schema: "mysql"
 mariadb_backup_database_user: "{% if mariadb_loadbalancer == 'haproxy' %}backup{% else %}{{ mariadb_shard_backup_user_prefix }}{{ mariadb_shard_id | string }}{% endif %}"
 mariadb_backup_type: "full"
 mariadb_backup_possible: "{{ mariadb_loadbalancer != 'haproxy' or inventory_hostname in mariadb_default_database_shard_hosts }}"

--- a/ansible/roles/mariadb/tasks/register.yml
+++ b/ansible/roles/mariadb/tasks/register.yml
@@ -33,21 +33,6 @@
   when:
     - inventory_hostname == groups[mariadb_shard_group][0]
 
-- name: Creating the Mariabackup database
-  become: true
-  kolla_toolbox:
-    container_engine: "{{ kolla_container_engine }}"
-    module_name: mysql_db
-    module_args:
-      login_host: "{{ api_interface_address }}"
-      login_port: "{{ mariadb_port }}"
-      login_user: "{{ mariadb_shard_database_user }}"
-      login_password: "{{ database_password }}"
-      name: "{{ mariadb_backup_database_schema }}"
-  when:
-    - enable_mariabackup | bool
-    - inventory_hostname == mariadb_backup_host
-
 - name: Creating database backup user and setting permissions
   become: true
   kolla_toolbox:


### PR DESCRIPTION
In 2023.1, mariadb was at version 10.6, which meant that the PERCONA_SCHEMA.xtrabackup_history table was used to log historicals for backups.

Starting in 2023.2 onwards, mariadb is at version 10.11, and the default table used is now mysql.mariadb_backup_history.

Because the mysql database already exists, there is no reason to try and create it. Instead, we just need to update the defaults and ensure the permissions get added to the correct database.

Related-Bug: #2061889
Change-Id: If146d8f896c70374884807d42ca0e12df3276d48 (cherry picked from commit 7aea1d3ee4cb1002d657c01af14e24218c3e09f8)